### PR TITLE
Update cloudbees-folder dependency to 5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>4.5</version>
+      <version>5.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
As noted in [release notes](https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Folders+Plugin), 5.0 has a change which unfortunately I could not manage to make binary compatible for accesses to `FolderProperty.owner`. The only known solution is to rebuild against 5.x and release a corresponding update to the downstream plugin.

@reviewbybees esp. @stephenc
